### PR TITLE
Fixed Default Image Color for Dark and Light Mode

### DIFF
--- a/Example/Shared/Additional Example Source Code/Helpers/URLImage/URLImageView.swift
+++ b/Example/Shared/Additional Example Source Code/Helpers/URLImage/URLImageView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct URLImageView: View {
     @ObservedObject var urlImageModel: URLImageModel
+    @Environment(\.colorScheme) var colorScheme
     
     init(urlString: String?) {
         urlImageModel = URLImageModel(urlString: urlString)
@@ -19,6 +20,7 @@ struct URLImageView: View {
     var body: some View {
         Image(uiImage: urlImageModel.image ?? URLImageView.defaultImage!)
             .resizable()
+            .foregroundColor(colorScheme == .dark ? .white : .black )
     }
     
     static var defaultImage = UIImage(named: "defaultImage")

--- a/Example/Shared/Assets.xcassets/defaultImage.imageset/Contents.json
+++ b/Example/Shared/Assets.xcassets/defaultImage.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
**I found default image in tabs was not looking good in dark mode, so I fixed that for dark and light mode**

Changes proposed in this request:
* Created an environment observer for colorScheme 
* Converted default image to type template image in asset
* Given foreground color depending on colorScheme

The image is looking good in both, dark and light mode 👇🏻

![ezgif com-gif-maker](https://user-images.githubusercontent.com/63144490/137615148-33b9bedb-49e0-4683-b614-f154eb5f9127.gif)


