### PR TITLE
PagerTabItemModifier Crash

### DIFF
--- a/Sources/NavigationBarStyles/IndicatorBarView.swift
+++ b/Sources/NavigationBarStyles/IndicatorBarView.swift
@@ -17,13 +17,13 @@ internal struct IndicatorBarView<Indicator: View>: View {
         HStack {
             let totalItemWidth = (settings.width - (style.tabItemSpacing * CGFloat(dataStore.itemsCount - 1)))
             let navBarItemWidth = totalItemWidth / CGFloat(dataStore.itemsCount)
-            if let width = navBarItemWidth, width > 0, width <= settings.width {
-                let x = -settings.contentOffset / CGFloat(dataStore.itemsCount) + width / 2
+            if navBarItemWidth > 0, navBarItemWidth <= settings.width {
+                let x = -settings.contentOffset / CGFloat(dataStore.itemsCount) + navBarItemWidth / 2
 
                 indicator
                     .foregroundColor(style.indicatorBarColor)
                     .animation(.default)
-                    .frame(width: width)
+                    .frame(width: navBarItemWidth)
                     .position(x: x, y: 0)
             }
         }

--- a/Sources/NavigationBarStyles/IndicatorBarView.swift
+++ b/Sources/NavigationBarStyles/IndicatorBarView.swift
@@ -17,13 +17,13 @@ internal struct IndicatorBarView<Indicator: View>: View {
         HStack {
             let totalItemWidth = (settings.width - (style.tabItemSpacing * CGFloat(dataStore.itemsCount - 1)))
             let navBarItemWidth = totalItemWidth / CGFloat(dataStore.itemsCount)
-            if navBarItemWidth > 0, navBarItemWidth <= settings.width {
-                let x = -settings.contentOffset / CGFloat(dataStore.itemsCount) + navBarItemWidth / 2
+            if let width = navBarItemWidth, width > 0, width <= settings.width {
+                let x = -settings.contentOffset / CGFloat(dataStore.itemsCount) + width / 2
 
                 indicator
                     .foregroundColor(style.indicatorBarColor)
                     .animation(.default)
-                    .frame(width: navBarItemWidth)
+                    .frame(width: width)
                     .position(x: x, y: 0)
             }
         }

--- a/Sources/PagerTabItemModifier.swift
+++ b/Sources/PagerTabItemModifier.swift
@@ -21,7 +21,7 @@ struct PagerTabItemModifier<NavTabView: View>: ViewModifier {
                 .onAppear {
                     DispatchQueue.main.async {
                         let frame = reader.frame(in: .named("PagerViewScrollView"))
-                        index = Int(round(frame.minX / frame.width))
+                        index = frame.width == 0 ? 0 : Int(round(frame.minX / frame.width))
                         let tabView = navTabView()
                         let tabViewDelegate = tabView as? PagerTabViewDelegate
                         dataStore.setView(AnyView(tabView), at: index)


### PR DESCRIPTION
PagerTabItemModifier was leading to crash on divide by zero. Fixed this by checking for zero


