### PR TITLE
fixes #140, problem where only the first tab appears on ios 18

### DIFF
--- a/Sources/PagerTabStripView.swift
+++ b/Sources/PagerTabStripView.swift
@@ -92,7 +92,7 @@ private struct WrapperPagerTabStripView<SelectionType, Content>: View where Sele
 
     @MainActor public var body: some View {
         GeometryReader { geometryProxy in
-            LazyHStack(spacing: 0) {
+            HStack(spacing: 0) {
                 content
                     .frame(width: geometryProxy.size.width)
             }


### PR DESCRIPTION
I'm sure there's probably something deeper at work here. If folks really depend on the `LazyHStack` (vs. `HStack`), a different fix would need to be found. 

